### PR TITLE
Add support for Guiceberry @TestScoped annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,6 +240,12 @@
       <artifactId>javax.inject</artifactId>
       <version>1</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.guiceberry</groupId>
+      <artifactId>guiceberry</artifactId>
+      <version>3.3.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
+++ b/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.acai;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.Key;
+import com.google.inject.Provider;
+import com.google.inject.Scope;
+import java.lang.annotation.Annotation;
+
+/**
+ * Module which can be installed to provide some limited compatibility with Guiceberry.
+ *
+ * <p>Currently installing this module will allow you to reuse modules designed for Guiceberry which
+ * make use of its @TestScoped annotation.
+ */
+public class GuiceberryCompatibilityModule extends AbstractModule {
+  private static final String GUICEBRRY_TEST_SCOPED_ANNOTATION = "com.google.guiceberry.TestScoped";
+
+  @Override
+  protected void configure() {
+    Provider<TestScope> scopeProvider = getProvider(Key.get(TestScope.class, AcaiInternal.class));
+    Scope scope =
+        new Scope() {
+          @Override
+          public <T> Provider<T> scope(Key<T> key, Provider<T> provider) {
+            return scopeProvider.get().scope(key, provider);
+          }
+        };
+
+    try {
+      bindScope(
+          Class.forName(GUICEBRRY_TEST_SCOPED_ANNOTATION).asSubclass(Annotation.class), scope);
+    } catch (ClassNotFoundException | ClassCastException e) {
+      throw new RuntimeException(
+          "GuiceberryCompatibilityModule installed but Guiceberry is not available.", e);
+    }
+  }
+}

--- a/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
+++ b/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.acai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import javax.inject.Inject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GuiceberryCompatibilityModuleTest {
+  @Mock private Statement statement;
+  @Mock private FrameworkMethod frameworkMethod;
+
+  @Test
+  public void sameInstanceInjectedWithinTest() throws Throwable {
+    FakeTestClass test = new FakeTestClass();
+
+    new Acai(GuiceberryCompatibilityModule.class)
+        .apply(statement, frameworkMethod, test)
+        .evaluate();
+
+    assertThat(test.instanceOne).isNotNull();
+    assertThat(test.instanceTwo).isSameAs(test.instanceOne);
+  }
+
+  @Test
+  public void differentInstanceInjectedAcrossTests() throws Throwable {
+    FakeTestClass testOne = new FakeTestClass();
+    FakeTestClass testTwo = new FakeTestClass();
+
+    new Acai(GuiceberryCompatibilityModule.class)
+        .apply(statement, frameworkMethod, testOne)
+        .evaluate();
+    new Acai(GuiceberryCompatibilityModule.class)
+        .apply(statement, frameworkMethod, testTwo)
+        .evaluate();
+
+    assertThat(testOne.instanceOne).isNotSameAs(testTwo.instanceOne);
+  }
+
+  private static class FakeTestClass {
+    @Inject MyTestScopedClass instanceOne;
+    @Inject MyTestScopedClass instanceTwo;
+  }
+
+  @com.google.guiceberry.TestScoped
+  private static class MyTestScopedClass {}
+}


### PR DESCRIPTION
Allows for some level of compatibility between modules created for use
with Guiceberry and Acai making it easier to migrate a codebase from one
to another.