### PR TITLE
Add support for Guava's TearDownAccepter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -189,7 +189,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>21.0</version>
+      <version>24.0-jre</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava-testlib</artifactId>
+      <version>24.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.errorprone</groupId>

--- a/src/main/java/com/google/acai/Acai.java
+++ b/src/main/java/com/google/acai/Acai.java
@@ -19,7 +19,7 @@ package com.google.acai;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.acai.TestScope.TestScopeModule;
-import com.google.acai.TestingServiceModule.NoopTestingServiceModule;
+import com.google.acai.TestingServiceModule.TearDownAccepterModule;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -106,7 +106,7 @@ public class Acai implements MethodRule {
     }
     Injector injector =
         Guice.createInjector(
-            instantiateModule(module), new NoopTestingServiceModule(), new TestScopeModule());
+            instantiateModule(module), new TearDownAccepterModule(), new TestScopeModule());
     TestEnvironment testEnvironment =
         new TestEnvironment(
             injector,


### PR DESCRIPTION
This will allow for easy reuse of non-Acai modules which already make
use of this feature.