### PR TITLE
Add compatibility with GuiceBerryEnvMain.

### DIFF
--- a/src/main/java/com/google/acai/Acai.java
+++ b/src/main/java/com/google/acai/Acai.java
@@ -27,6 +27,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Key;
 import com.google.inject.Module;
+import com.google.inject.util.Modules;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
@@ -104,9 +105,13 @@ public class Acai implements MethodRule {
     if (environments.containsKey(module)) {
       return environments.get(module);
     }
+    // Use modules override to configure TearDownAccepter and GuiceberryCompatibilityModule.
+    // This allows reuse of modules which install GuiceBerryModule by overriding its bindings
+    // with equivalent ones from Acai.
     Injector injector =
         Guice.createInjector(
-            instantiateModule(module), new TearDownAccepterModule(), new TestScopeModule());
+            Modules.override(instantiateModule(module), new TestScopeModule())
+                .with(new TearDownAccepterModule(), new GuiceberryCompatibilityModule()));
     TestEnvironment testEnvironment =
         new TestEnvironment(
             injector,

--- a/src/main/java/com/google/acai/AcaiInternal.java
+++ b/src/main/java/com/google/acai/AcaiInternal.java
@@ -18,10 +18,12 @@ package com.google.acai;
 
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
-import com.google.inject.BindingAnnotation;
 import java.lang.annotation.Retention;
+import javax.inject.Qualifier;
 
-/** Annotates bindings which are internal to Acai. */
+/**
+ * Annotates bindings which are internal to Acai.
+ */
 @Retention(RUNTIME)
-@BindingAnnotation
+@Qualifier
 @interface AcaiInternal {}

--- a/src/main/java/com/google/acai/TestScope.java
+++ b/src/main/java/com/google/acai/TestScope.java
@@ -28,6 +28,7 @@ import java.util.Map;
 
 /** Scope for bindings annotated with {@link TestScoped}. */
 class TestScope implements Scope {
+  static final TestScope INSTANCE = new TestScope();
   private final ThreadLocal<Map<Key<?>, Object>> values = new ThreadLocal<>();
 
   void enter() {
@@ -66,9 +67,8 @@ class TestScope implements Scope {
   static class TestScopeModule extends AbstractModule {
     @Override
     protected void configure() {
-      TestScope testScope = new TestScope();
-      bind(TestScope.class).annotatedWith(AcaiInternal.class).toInstance(testScope);
-      bindScope(TestScoped.class, testScope);
+      bind(TestScope.class).annotatedWith(AcaiInternal.class).toInstance(INSTANCE);
+      bindScope(TestScoped.class, INSTANCE);
     }
   }
 }


### PR DESCRIPTION
Also adapts GuiceberryCompatibilityModule to be always installed and
simply be a noop if no Guiceberry modules are configured. Makes use of
Modules.override to configure bindings which are also used in GuiceBerry
so that modules which install GuiceBerryModule can be more easily
resused in tests which use Acai.