### PR TITLE
Compatibility with TestScopeListener and TestWrapper.

### DIFF
--- a/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
+++ b/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
@@ -17,11 +17,15 @@
 package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 
 import com.google.guiceberry.GuiceBerryEnvMain;
 import com.google.guiceberry.GuiceBerryModule;
+import com.google.guiceberry.TestWrapper;
 import com.google.inject.AbstractModule;
+import com.google.inject.testing.guiceberry.TestScopeListener;
 import javax.inject.Inject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
@@ -33,6 +37,13 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class GuiceberryCompatibilityModuleTest {
   @Mock private Statement statement;
   @Mock private FrameworkMethod frameworkMethod;
+
+  @Before
+  public void setUp() {
+    ScopeListener.enteringScopeCount = 0;
+    ScopeListener.exitingScopeCount = 0;
+    Wrapper.runBeforeCount = 0;
+  }
 
   @Test
   public void sameInstanceInjectedWithinTest() throws Throwable {
@@ -71,6 +82,72 @@ public class GuiceberryCompatibilityModuleTest {
     assertThat(EnvMain.runCount).isEqualTo(1);
   }
 
+  @Test
+  public void testScopeListenerCalled() throws Throwable {
+    FakeTestClass test = new FakeTestClass();
+
+    assertThat(ScopeListener.enteringScopeCount).isEqualTo(0);
+    assertThat(ScopeListener.exitingScopeCount).isEqualTo(0);
+
+    new Acai(GuiceberryTestModule.class)
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                assertThat(ScopeListener.enteringScopeCount).isEqualTo(1);
+                assertThat(ScopeListener.exitingScopeCount).isEqualTo(0);
+              }
+            },
+            frameworkMethod,
+            test)
+        .evaluate();
+
+    assertThat(ScopeListener.enteringScopeCount).isEqualTo(1);
+    assertThat(ScopeListener.exitingScopeCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testWrapperCalled() throws Throwable {
+    FakeTestClass test = new FakeTestClass();
+
+    assertThat(Wrapper.runBeforeCount).isEqualTo(0);
+
+    new Acai(GuiceberryTestModule.class)
+        .apply(
+            new Statement() {
+              @Override
+              public void evaluate() {
+                assertThat(Wrapper.runBeforeCount).isEqualTo(1);
+              }
+            },
+            frameworkMethod,
+            test)
+        .evaluate();
+
+    assertThat(Wrapper.runBeforeCount).isEqualTo(1);
+  }
+
+  @Test
+  public void testWrapperExceptionPropagated() throws Throwable {
+    FakeTestClass test = new FakeTestClass();
+
+    try {
+      new Acai(ThrowingWrapperModule.class)
+          .apply(
+              new Statement() {
+                @Override
+                public void evaluate() {
+                  assertWithMessage("Test should not run when TestWrapper throws").fail();
+                }
+              },
+              frameworkMethod,
+              test)
+          .evaluate();
+      assertWithMessage("Exception from TestWrapper should be propagated").fail();
+    } catch (TestException expected) {
+    }
+  }
+
   private static class FakeTestClass {
     @Inject MyTestScopedClass instanceOne;
     @Inject MyTestScopedClass instanceTwo;
@@ -85,6 +162,8 @@ public class GuiceberryCompatibilityModuleTest {
       install(new GuiceBerryModule());
       install(new GuiceberryCompatibilityModule());
       bind(GuiceBerryEnvMain.class).to(EnvMain.class);
+      bind(TestScopeListener.class).to(ScopeListener.class);
+      bind(TestWrapper.class).to(Wrapper.class);
     }
   }
 
@@ -96,4 +175,45 @@ public class GuiceberryCompatibilityModuleTest {
       runCount++;
     }
   }
+
+  private static class ScopeListener implements TestScopeListener {
+    static int enteringScopeCount = 0;
+    static int exitingScopeCount = 0;
+
+    @Override
+    public void enteringScope() {
+      enteringScopeCount++;
+    }
+
+    @Override
+    public void exitingScope() {
+      exitingScopeCount++;
+    }
+  }
+
+  private static class Wrapper implements TestWrapper {
+    static int runBeforeCount = 0;
+
+    @Override
+    public void toRunBeforeTest() {
+      runBeforeCount++;
+    }
+  }
+
+  static class ThrowingWrapperModule extends AbstractModule {
+    @Override
+    protected void configure() {
+      install(new GuiceBerryModule());
+      bind(TestWrapper.class).to(ThrowingWrapper.class);
+    }
+  }
+
+  private static class ThrowingWrapper implements TestWrapper {
+    @Override
+    public void toRunBeforeTest() throws TestException {
+      throw new TestException();
+    }
+  }
+
+  private static class TestException extends RuntimeException {}
 }


### PR DESCRIPTION
Allows modules which have bindings for these GuiceBerry interfaces to be
reused by Acai tests.