### PR TITLE
 TestingServiceModule.forServices accepts instances

### DIFF
--- a/src/main/java/com/google/acai/TestingServiceModule.java
+++ b/src/main/java/com/google/acai/TestingServiceModule.java
@@ -54,7 +54,7 @@ public abstract class TestingServiceModule extends AbstractModule {
   }
   
   /** Returns a new module which will configure bindings for all the specified {@code services}. */
-  public static TestingServiceModule forServices(
+  public static TestingServiceModule forServiceInstances(
       Iterable<TestingService> services) {
     return new TestingServiceModule() {
       @Override
@@ -74,10 +74,9 @@ public abstract class TestingServiceModule extends AbstractModule {
   }
   
   /** Returns a new module which will configure bindings for all the specified {@code services}. */
-  @SafeVarargs
   @CheckReturnValue
   public static TestingServiceModule forServices(TestingService... services) {
-    return forServices(ImmutableList.copyOf(services));
+    return forServiceInstances(ImmutableList.copyOf(services));
   }
 
   @Override

--- a/src/main/java/com/google/acai/TestingServiceModule.java
+++ b/src/main/java/com/google/acai/TestingServiceModule.java
@@ -52,19 +52,6 @@ public abstract class TestingServiceModule extends AbstractModule {
       }
     };
   }
-  
-  /** Returns a new module which will configure bindings for all the specified {@code services}. */
-  public static TestingServiceModule forServiceInstances(
-      Iterable<TestingService> services) {
-    return new TestingServiceModule() {
-      @Override
-      protected void configureTestingServices() {
-        for (TestingService service : services) {
-          bindTestingService(service);
-        }
-      }
-    };
-  }
 
   /** Returns a new module which will configure bindings for all the specified {@code services}. */
   @SafeVarargs
@@ -76,7 +63,14 @@ public abstract class TestingServiceModule extends AbstractModule {
   /** Returns a new module which will configure bindings for all the specified {@code services}. */
   @CheckReturnValue
   public static TestingServiceModule forServices(TestingService... services) {
-    return forServiceInstances(ImmutableList.copyOf(services));
+    return new TestingServiceModule() {
+      @Override
+      protected void configureTestingServices() {
+        for (TestingService service : services) {
+          bindTestingService(service);
+        }
+      }
+    };
   }
 
   @Override

--- a/src/main/java/com/google/acai/TestingServiceModule.java
+++ b/src/main/java/com/google/acai/TestingServiceModule.java
@@ -52,11 +52,31 @@ public abstract class TestingServiceModule extends AbstractModule {
       }
     };
   }
+  
+  /** Returns a new module which will configure bindings for all the specified {@code services}. */
+  public static TestingServiceModule forServices(
+      Iterable<TestingService> services) {
+    return new TestingServiceModule() {
+      @Override
+      protected void configureTestingServices() {
+        for (TestingService service : services) {
+          bindTestingService(service);
+        }
+      }
+    };
+  }
 
   /** Returns a new module which will configure bindings for all the specified {@code services}. */
   @SafeVarargs
   @CheckReturnValue
   public static TestingServiceModule forServices(Class<? extends TestingService>... services) {
+    return forServices(ImmutableList.copyOf(services));
+  }
+  
+  /** Returns a new module which will configure bindings for all the specified {@code services}. */
+  @SafeVarargs
+  @CheckReturnValue
+  public static TestingServiceModule forServices(TestingService... services) {
     return forServices(ImmutableList.copyOf(services));
   }
 

--- a/src/test/java/com/google/acai/TestingServiceModuleTest.java
+++ b/src/test/java/com/google/acai/TestingServiceModuleTest.java
@@ -33,14 +33,7 @@ public class TestingServiceModuleTest {
   @Test
   public void servicesAreBound() {
     final ServiceToBindByInstance serviceInstance = new ServiceToBindByInstance();
-    Injector injector =
-        Guice.createInjector(
-            new TestingServiceModule() {
-              @Override
-              protected void configureTestingServices() {
-                bindTestingService(serviceInstance);
-              }
-            });
+    Injector injector = Guice.createInjector(TestingServiceModule.forServices(serviceInstance));
 
     Set<TestingService> boundServices =
         injector.getInstance(new Key<Set<TestingService>>(AcaiInternal.class) {});


### PR DESCRIPTION
This removes some boilerplate when using `bindTestingService` with an instance instead of a class.