### PR TITLE
Update Java version in Travis CI config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 sudo: false
 jdk:
-  - oraclejdk8
+  - openjdk8
 notifications:
   email: false
 after_success:


### PR DESCRIPTION
Using 8 gives the error "Expected feature release number in range of 9
to 15, but got: 8"

See: https://travis-ci.org/github/google/acai/builds/678191592