### PR TITLE
Add AcaiBoundFieldModule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - openjdk8
+  - openjdk11
 notifications:
   email: false
 after_success:

--- a/pom.xml
+++ b/pom.xml
@@ -63,22 +63,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
+        <version>3.8.0</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-          <showWarnings>true</showWarnings>
-          <showDeprecation>true</showDeprecation>
-          <compilerId>javac-with-errorprone</compilerId>
-          <forceJavacCompilerUse>true</forceJavacCompilerUse>
+          <source>8</source>
+          <target>8</target>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-compiler-javac-errorprone</artifactId>
-            <version>2.8</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
@@ -89,19 +78,6 @@
             <id>attach-sources</id>
             <goals>
               <goal>jar-no-fork</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
             </goals>
           </execution>
         </executions>
@@ -187,11 +163,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
       <version>24.0-jre</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.2.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,11 @@
       <version>3.3.1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.inject.extensions</groupId>
+      <artifactId>guice-testlib</artifactId>
+      <version>4.2.3</version>
+    </dependency>
   </dependencies>
 
   <profiles>

--- a/src/main/java/com/google/acai/AcaiBoundFieldModule.java
+++ b/src/main/java/com/google/acai/AcaiBoundFieldModule.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.acai;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.AbstractModule;
+import com.google.inject.spi.Message;
+import com.google.inject.testing.fieldbinder.BoundFieldModule;
+import com.google.inject.testing.fieldbinder.BoundFieldModule.BoundFieldInfo;
+import java.util.function.Function;
+
+/**
+ * Wrapper around {@link BoundFieldModule}. Binds all fields annotated with {@code Bind(lazy=true)}
+ * of the given class to a {@code TestScoped} instance, so the values are reset to default for every
+ * test.
+ *
+ * <p>To use the lazy binding is important to either {@code @Inject} a {@code Provider} in your
+ * class under test, or inject a {@code Provider} of the class in your test as shown below.
+ *
+ * <p>Usage:
+ *
+ * <pre>{@code
+ * @Rule public final Acai acai = new Acai(TestEnv.class);
+ *
+ * public static class TestEnv extends AbstractModule {
+ *   protected void configure() { install(AcaiBoundFieldModule.of(Vars.class); }
+ * }
+ *
+ * public static class Vars {
+ *   @Bind(lazy = true) @MyAnnotation String value = "default";
+ * }
+ *
+ * @Inject Vars vars;
+ * @Inject Provider<ClassUnderTest> instance; // injects @MyAnnotation String
+ *
+ * @Test public void test1() {
+ *   vars.value = "test";
+ *
+ *   instance.get().foo(); // uses "test"
+ * }
+ *
+ * @Test public void test2() {
+ *   instance.get().foo(); // uses "default"
+ * }
+ * }</pre>
+ */
+public final class AcaiBoundFieldModule<T> extends AbstractModule {
+  private final Class<T> clazz;
+  private final T instance;
+
+  private AcaiBoundFieldModule(Class<T> clazz) {
+    this.clazz = clazz;
+
+    try {
+      instance = clazz.getDeclaredConstructor().newInstance();
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Use like: {@code install(AcaiBoundFieldModule.of(Vars.class));} in your TestEnv.
+   *
+   * <p>NOTE: The class passed must be {@code public static}.
+   */
+  public static <T> AcaiBoundFieldModule<T> of(Class<T> clazz) {
+    return new AcaiBoundFieldModule<>(clazz);
+  }
+
+  @Override
+  protected void configure() {
+    BoundFieldModule module = BoundFieldModule.of(instance);
+    ImmutableMap<BoundFieldInfo, Object> defaultValues =
+        module.getBoundFields().stream()
+            .filter(
+                info -> {
+                  if (!info.getBindAnnotation().lazy()) {
+                    binder()
+                        .addError(
+                            new Message(
+                                info.getField(), "All bindings must use @Bind(lazy = true)"));
+                    return false;
+                  } else {
+                    return true;
+                  }
+                })
+            .collect(toImmutableMap(Function.identity(), BoundFieldInfo::getValue));
+
+    TestingService testingService =
+        new TestingService() {
+          @BeforeTest
+          void resetInstance() {
+            defaultValues.forEach(
+                (info, value) -> {
+                  try {
+                    info.getField().set(instance, value);
+                  } catch (IllegalAccessException e) {
+                    throw new RuntimeException(e);
+                  }
+                });
+          }
+        };
+
+    bind(clazz).toInstance(instance);
+    install(module);
+
+    install(
+        new TestingServiceModule() {
+          @Override
+          protected void configureTestingServices() {
+            bindTestingService(testingService);
+          }
+        });
+  }
+}

--- a/src/test/java/com/google/acai/AcaiBoundFieldModuleTest.java
+++ b/src/test/java/com/google/acai/AcaiBoundFieldModuleTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.acai;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.inject.AbstractModule;
+import com.google.inject.testing.fieldbinder.Bind;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.inject.Inject;
+import javax.inject.Provider;
+import javax.inject.Qualifier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.model.Statement;
+
+@RunWith(JUnit4.class)
+public class AcaiBoundFieldModuleTest {
+
+  private static final String DEFAULT = "default";
+  private static final String SPECIAL = "special";
+
+  public static class TestEnv extends AbstractModule {
+    @Override
+    protected void configure() {
+      install(AcaiBoundFieldModule.of(Provided.class));
+    }
+  }
+
+  @Qualifier
+  @Retention(RetentionPolicy.RUNTIME)
+  @interface MyAnnotation {}
+
+  private static class Provided {
+    @Bind(lazy = true)
+    @MyAnnotation
+    String value = DEFAULT;
+  }
+
+  private static class Target {
+    @Inject Provided provided;
+    @Inject @MyAnnotation Provider<String> valueProvider;
+  }
+
+  @Test
+  public void bindingsAreTestScoped() {
+    // Creating the rule in here since we want to test the scoping.
+    Acai acai = new Acai(TestEnv.class);
+    Target target = new Target();
+
+    acai.apply(
+        new Statement() {
+          @Override
+          public void evaluate() {
+            assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
+            target.provided.value = SPECIAL;
+            assertThat(target.valueProvider.get()).isEqualTo(SPECIAL);
+          }
+        },
+        null,
+        target);
+
+    acai.apply(
+        new Statement() {
+          @Override
+          public void evaluate() {
+            assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
+          }
+        },
+        null,
+        target);
+  }
+}


### PR DESCRIPTION
A wrapper around Guice's BoundFieldModule which resets using an Acai TestingService.

Had to remove ErrorProne & Javadoc to be able to locally build using JDK11.