### PR TITLE
Re-enable Errorprone

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ jdk:
 notifications:
   email: false
 after_success:
-  - mvn clean cobertura:cobertura coveralls:report
+  - mvn clean test jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -99,24 +99,16 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.7</version>
-        <configuration>
-          <check>
-            <branchRate>50</branchRate>
-            <lineRate>70</lineRate>
-            <haltOnFailure>true</haltOnFailure>
-            <totalBranchRate>50</totalBranchRate>
-            <totalLineRate>70</totalLineRate>
-            <packageLineRate>70</packageLineRate>
-            <packageBranchRate>50</packageBranchRate>
-          </check>
-          <formats>
-            <format>html</format>
-            <format>xml</format>
-          </formats>
-        </configuration>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.eluder.coveralls</groupId>
@@ -155,7 +147,7 @@
             <configuration>
               <rules>
                 <requireMavenVersion>
-                  <version>3.1</version>
+                  <version>3.3.9</version>
                 </requireMavenVersion>
               </rules>
             </configuration>
@@ -169,6 +161,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <javac.version>9+181-r4173-1</javac.version>
     <auto-value.version>1.7.4</auto-value.version>
+    <jacoco.version>0.8.6</jacoco.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.1</version>
         <configuration>
           <source>8</source>
           <target>8</target>
@@ -88,7 +88,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.0.1</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.8.1</version>
         <configuration>
           <rulesUri>file://${basedir}/version-rules.xml</rulesUri>
         </configuration>
@@ -145,7 +145,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-maven</id>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,16 @@
         <configuration>
           <source>8</source>
           <target>8</target>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
           <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.5.1</version>
+            </path>
             <path>
               <groupId>com.google.auto.value</groupId>
               <artifactId>auto-value</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <javac.version>9+181-r4173-1</javac.version>
     <auto-value.version>1.7.4</auto-value.version>
   </properties>
 
@@ -268,6 +269,26 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>jdk8</id>
+      <activation>
+        <jdk>1.8</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <fork>true</fork>
+              <compilerArgs combine.children="append">
+                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
+              </compilerArgs>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
Following https://errorprone.info/docs/installation

This works locally as well!

I believe the reason this didn't work before was that I hadn't removed the old dependency on 2.2.0 in the `dependencies` list and it clashed with 2.5.1 as specified in `annotationProcessorPaths`