### PR TITLE
Fix AcaiBoundFieldModuleTest

### DIFF
--- a/src/main/java/com/google/acai/AcaiBoundFieldModule.java
+++ b/src/main/java/com/google/acai/AcaiBoundFieldModule.java
@@ -35,30 +35,30 @@ import java.util.function.Function;
  *
  * <p>Usage:
  *
- * <pre>{@code
- * @Rule public final Acai acai = new Acai(TestEnv.class);
+ * <pre><code>
+ * &#64;Rule public final Acai acai = new Acai(TestEnv.class);
  *
  * public static class TestEnv extends AbstractModule {
  *   protected void configure() { install(AcaiBoundFieldModule.of(Vars.class); }
  * }
  *
  * public static class Vars {
- *   @Bind(lazy = true) @MyAnnotation String value = "default";
+ *   &#64;Bind(lazy = true) &#64;MyAnnotation String value = "default";
  * }
  *
- * @Inject Vars vars;
- * @Inject Provider<ClassUnderTest> instance; // injects @MyAnnotation String
+ * &#64;Inject Vars vars;
+ * &#64;Inject Provider&lt;ClassUnderTest&rt; instance; // injects &#64;MyAnnotation String
  *
- * @Test public void test1() {
+ * &#64;Test public void test1() {
  *   vars.value = "test";
  *
  *   instance.get().foo(); // uses "test"
  * }
  *
- * @Test public void test2() {
+ * &#64;Test public void test2() {
  *   instance.get().foo(); // uses "default"
  * }
- * }</pre>
+ * </code></pre>
  */
 public final class AcaiBoundFieldModule<T> extends AbstractModule {
   private final Class<T> clazz;

--- a/src/test/java/com/google/acai/AcaiBoundFieldModuleTest.java
+++ b/src/test/java/com/google/acai/AcaiBoundFieldModuleTest.java
@@ -47,7 +47,7 @@ public class AcaiBoundFieldModuleTest {
   @Retention(RetentionPolicy.RUNTIME)
   @interface MyAnnotation {}
 
-  private static class Provided {
+  static class Provided {
     @Bind(lazy = true)
     @MyAnnotation
     String value = DEFAULT;
@@ -59,31 +59,33 @@ public class AcaiBoundFieldModuleTest {
   }
 
   @Test
-  public void bindingsAreTestScoped() {
+  public void bindingsAreTestScoped() throws Throwable {
     // Creating the rule in here since we want to test the scoping.
     Acai acai = new Acai(TestEnv.class);
     Target target = new Target();
 
     acai.apply(
-        new Statement() {
-          @Override
-          public void evaluate() {
-            assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
-            target.provided.value = SPECIAL;
-            assertThat(target.valueProvider.get()).isEqualTo(SPECIAL);
-          }
-        },
-        null,
-        target);
+            new Statement() {
+              @Override
+              public void evaluate() {
+                assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
+                target.provided.value = SPECIAL;
+                assertThat(target.valueProvider.get()).isEqualTo(SPECIAL);
+              }
+            },
+            null,
+            target)
+        .evaluate();
 
     acai.apply(
-        new Statement() {
-          @Override
-          public void evaluate() {
-            assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
-          }
-        },
-        null,
-        target);
+            new Statement() {
+              @Override
+              public void evaluate() {
+                assertThat(target.valueProvider.get()).isEqualTo(DEFAULT);
+              }
+            },
+            null,
+            target)
+        .evaluate();
   }
 }


### PR DESCRIPTION
We didn't actually evaluate the statement.

Also fixing the Javadoc formatting for the code sample since processors disagree on how to parse the large `{@code ...}` block.