### PR TITLE
Update CI to JDK 25 and bump dependencies for compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 25
           cache: maven
       - name: Run tests
         run: mvn -B test

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -63,19 +63,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.13.0</version>
         <configuration>
-          <source>8</source>
-          <target>8</target>
+          <release>8</release>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
+            <arg>--should-stop=ifError=FLOW</arg>
             <arg>-Xplugin:ErrorProne</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.5.1</version>
+              <version>2.36.0</version>
             </path>
             <path>
               <groupId>com.google.auto.value</groupId>
@@ -164,9 +164,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <javac.version>9+181-r4173-1</javac.version>
-    <auto-value.version>1.7.4</auto-value.version>
-    <jacoco.version>0.8.6</jacoco.version>
+    <auto-value.version>1.10.4</auto-value.version>
+    <jacoco.version>0.8.12</jacoco.version>
   </properties>
 
   <dependencies>
@@ -178,7 +177,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>30.1-jre</version>
+      <version>32.0.0-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -188,12 +187,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>4.2.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-      <version>4.2.3</version>
+      <version>5.1.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -215,8 +209,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <artifactId>mockito-core</artifactId>
+      <version>5.14.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -239,7 +233,7 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-testlib</artifactId>
-      <version>4.2.3</version>
+      <version>5.1.0</version>
     </dependency>
   </dependencies>
 
@@ -267,26 +261,6 @@
                 </goals>
               </execution>
             </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-    <profile>
-      <id>jdk8</id>
-      <activation>
-        <jdk>1.8</jdk>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-              <fork>true</fork>
-              <compilerArgs combine.children="append">
-                <arg>-J-Xbootclasspath/p:${settings.localRepository}/com/google/errorprone/javac/${javac.version}/javac-${javac.version}.jar</arg>
-              </compilerArgs>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/src/test/java/com/google/acai/AcaiTest.java
+++ b/src/test/java/com/google/acai/AcaiTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AcaiTest {

--- a/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
+++ b/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GuiceberryCompatibilityModuleTest {

--- a/src/test/java/com/google/acai/TestScopeTest.java
+++ b/src/test/java/com/google/acai/TestScopeTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestScopeTest {

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass


### PR DESCRIPTION
## Summary
- Bump CI workflow from JDK 11 to JDK 25 (latest LTS, `temurin`).
- Bump dependencies needed to build and run tests on a modern JDK: Guice 4 → 5.1 (drop `guice-multibindings`), `mockito-all` 1.10.19 → `mockito-core` 5.14.2, ErrorProne 2.5.1 → 2.36.0, maven-compiler-plugin 3.8.1 → 3.13.0, jacoco 0.8.6 → 0.8.12, AutoValue 1.7.4 → 1.10.4, guava-testlib 30.1 → 32.0.0.
- Add the `--add-exports` / `--add-opens` JVM args required for ErrorProne on JDK 16+.
- Switch `<source>8</source><target>8</target>` to `<release>8</release>` so the published artifact still targets JDK 8 bytecode — no consumer-facing target change.
- Three test files updated to import `org.mockito.junit.MockitoJUnitRunner` (the deprecated `org.mockito.runners` path was removed in Mockito 5).
- Remove the now-dead `jdk8` Maven profile and its `javac.version` property.

Opened as draft to verify the workflow runs green before marking ready for review.

## Test plan
- [ ] CI workflow runs and passes on this PR