### PR TITLE
Upgrade to JDK 26 and modernise build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 25
+      - name: Set up JDK 26
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 25
+          java-version: 26
           cache: maven
       - name: Run tests
         run: mvn -B test

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -6,5 +6,7 @@
 --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.13.0</version>
+        <version>3.14.0</version>
         <configuration>
-          <release>8</release>
+          <release>26</release>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>--should-stop=ifError=FLOW</arg>
@@ -75,7 +75,7 @@
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
-              <version>2.36.0</version>
+              <version>2.49.0</version>
             </path>
             <path>
               <groupId>com.google.auto.value</groupId>
@@ -165,7 +165,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <auto-value.version>1.10.4</auto-value.version>
-    <jacoco.version>0.8.12</jacoco.version>
+    <jacoco.version>0.8.14</jacoco.version>
   </properties>
 
   <dependencies>
@@ -187,7 +187,7 @@
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
-      <version>5.1.0</version>
+      <version>6.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.auto.value</groupId>
@@ -233,7 +233,7 @@
     <dependency>
       <groupId>com.google.inject.extensions</groupId>
       <artifactId>guice-testlib</artifactId>
-      <version>5.1.0</version>
+      <version>6.0.0</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
## Summary
- Move CI from JDK 25 to JDK 26 and unpin the compiler release target from Java 8 to 26
- Bump build tooling to versions that handle JDK 26 (maven-compiler-plugin 3.14.0, error_prone_core 2.49.0, jacoco 0.8.14)
- Bump Guice/guice-testlib 5.1.0 → 6.0.0 (Guice 5's bundled ASM rejects Java 26 bytecode at test time; 6.0.0 still supports `javax.inject` so source is unchanged)
- Add the `--add-exports` flags for `javac.code` and `javac.comp` that error-prone 2.49.0 requires on top of the existing `--add-opens`

## Test plan
- [ ] CI passes on JDK 26
- [ ] `mvn -B test` green locally on JDK 26 (43/43 tests pass)
- [ ] `mvn jacoco:report` produces a coverage report without instrumentation errors