### PR TITLE
Migrate publishing from OSSRH to Central Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,14 +121,13 @@
         <version>4.3.0</version>
       </plugin>
       <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.8</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.10.0</version>
         <extensions>true</extensions>
         <configuration>
-           <serverId>ossrh</serverId>
-           <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-           <autoReleaseAfterClose>true</autoReleaseAfterClose>
+          <publishingServerId>central</publishingServerId>
+          <autoPublish>false</autoPublish>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
## Summary
- Sonatype OSSRH (`oss.sonatype.org`) was sunset on 2025-06-30; its staging API now returns HTTP 402, so `mvn release:perform` would fail at the deploy step
- Replaces `nexus-staging-maven-plugin` with `central-publishing-maven-plugin` 0.10.0, pointing at the new Central Portal (`https://central.sonatype.com`)
- `autoPublish` left disabled — the deployment lands as a validated draft in the portal UI and is published manually for now; can flip to `true` once a couple of releases have run cleanly

## Credential change required
The publisher's `~/.m2/settings.xml` must switch from the old OSSRH `ossrh` username/password to a Central Portal user token under `<id>central</id>`. Token is generated at https://central.sonatype.com/account → "Generate User Token". The GPG signing setup is unchanged.

## Test plan
- [x] `mvn -B test` green on JDK 26 (43/43 tests pass; plugin extension loads cleanly)
- [ ] Dry-run `mvn deploy -P release-sign-artifacts` uploads a validated draft to the Central Portal without auto-publishing
- [ ] Real release (`mvn release:prepare && mvn release:perform`) produces a deployment that can be published from the portal UI

The "Update doc" follow-up: the internal release runbook still describes OSSRH and `nexus-staging-maven-plugin`; that doc needs the corresponding update.