### PR TITLE
Modernise release tooling and drop oss-parent:7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,12 +52,6 @@
     </developer>
   </developers>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <build>
     <plugins>
       <plugin>
@@ -97,6 +91,24 @@
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>3.12.0</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>3.3.1</version>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/src/main/java/com/google/acai/AcaiBoundFieldModule.java
+++ b/src/main/java/com/google/acai/AcaiBoundFieldModule.java
@@ -47,7 +47,7 @@ import java.util.function.Function;
  * }
  *
  * &#64;Inject Vars vars;
- * &#64;Inject Provider&lt;ClassUnderTest&rt; instance; // injects &#64;MyAnnotation String
+ * &#64;Inject Provider&lt;ClassUnderTest&gt; instance; // injects &#64;MyAnnotation String
  *
  * &#64;Test public void test1() {
  *   vars.value = "test";


### PR DESCRIPTION
## Summary
- `mvn release:prepare` on JDK 26 was crashing inside `maven-javadoc-plugin:2.7` (2010) — its transitive `commons-lang:2.4` calls `version.substring(0, 3)` on the Java version string, which fails for `"26"` (length 2)
- Pin `maven-javadoc-plugin` to 3.12.0 and `maven-release-plugin` to 3.3.1, overriding the ancient defaults inherited from the deprecated `org.sonatype.oss:oss-parent:7`
- Drop the `oss-parent:7` parent entirely — every modern plugin version is now overridden in this pom, the Central Portal migration replaced its distribution-management role, and GPG signing / sources / javadoc are wired up here directly
- Wire javadoc generation into the main build so CI catches doc breakage rather than discovering it during a release attempt
- Fixes one real bug surfaced by the new javadoc tool: a broken `&rt;` HTML entity in `AcaiBoundFieldModule`'s class javadoc (should have been `&gt;`)

## Test plan
- [x] `mvn -B clean package` succeeds on JDK 26 with javadoc + sources jars attached
- [x] All 43 tests still pass
- [ ] Once merged, `mvn release:prepare -DdryRun=true` runs to completion