### PR TITLE
Use HTTPS for SCM URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,8 @@
   <packaging>jar</packaging>
 
   <scm>
-    <connection>scm:git:git@github.com:google/acai.git</connection>
-    <developerConnection>scm:git:git@github.com:google/acai.git</developerConnection>
+    <connection>scm:git:https://github.com/google/acai.git</connection>
+    <developerConnection>scm:git:https://github.com/google/acai.git</developerConnection>
     <url>https://github.com/google/acai</url>
   </scm>
 


### PR DESCRIPTION
## Summary
- `mvn release:prepare` was failing with `Permission denied (publickey)` because the maven-release-plugin pushes through the `<developerConnection>` URL, which was set to `git@github.com:...` (SSH)
- Switch both `<connection>` and `<developerConnection>` to HTTPS so the plugin reuses the user's existing HTTPS credentials, matching the local `origin` remote

## Test plan
- [ ] After merge, `mvn release:prepare && mvn release:perform` completes the SCM push step on a machine without GitHub SSH keys configured