### PR TITLE
Activate release-sign-artifacts profile via releaseProfiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
         <version>3.3.1</version>
+        <configuration>
+          <releaseProfiles>release-sign-artifacts</releaseProfiles>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
## Summary
- maven-release-plugin 3.x no longer auto-passes `performRelease=true` to its forked deploy, so the `release-sign-artifacts` profile (which pulls in maven-gpg-plugin) was silently skipped during the 1.2 release — Central Portal rejected the upload for missing `.asc` signatures
- Naming the profile in `<releaseProfiles>` makes `release:perform` activate it explicitly, removing the `-Darguments="-DperformRelease=true"` workaround needed during 1.2

## Test plan
- [ ] Verified on next release: `mvn release:perform` (no extra `-Darguments`) signs and uploads to Central with `.asc` files attached