### PR TITLE
Refresh README: bump dep to 1.2 and add CI + Maven Central badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Acai
 
+[![Maven Central](https://img.shields.io/maven-central/v/com.google.acai/acai.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/com.google.acai/acai)
+[![CI](https://github.com/google/acai/actions/workflows/ci.yml/badge.svg)](https://github.com/google/acai/actions/workflows/ci.yml)
+
 Acai makes it easy to write functional tests of your application
 with JUnit4 and Guice.
 
@@ -28,13 +31,13 @@ your dependencies in `pom.xml`:
 <dependency>
   <groupId>com.google.acai</groupId>
   <artifactId>acai</artifactId>
-  <version>1.1</version>
+  <version>1.2</version>
   <scope>test</scope>
 </dependency>
 ```
 
 See the [artifact details on Maven Central](
-http://search.maven.org/#artifactdetails|com.google.acai|acai|1.1|)
+https://central.sonatype.com/artifact/com.google.acai/acai)
 for dependency information for other build systems or to simply download the
 jars.
 


### PR DESCRIPTION
## Summary
- Bump the example dependency to the just-released 1.2 and refresh the "artifact details" link to the Central Portal (the old `search.maven.org` deep-link URL was deprecated alongside OSSRH)
- Add two badges at the top, mirroring `google/guava`'s pattern:
  - Maven Central version (auto-updates from Central, no manual upkeep)
  - GitHub Actions CI status — replaces the Travis badge dropped in #40 when CI moved to Actions