### PR TITLE
Remove unused coveralls-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,11 +130,6 @@
         </executions>
       </plugin>
       <plugin>
-        <groupId>org.eluder.coveralls</groupId>
-        <artifactId>coveralls-maven-plugin</artifactId>
-        <version>4.3.0</version>
-      </plugin>
-      <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <version>0.10.0</version>


### PR DESCRIPTION
## Summary
- Drop the `coveralls-maven-plugin` from pom.xml. Its only job was uploading coverage to coveralls.io during the Travis CI era; since the move to GitHub Actions in #41 nothing has invoked it.
- Local coverage workflow is unchanged: `mvn jacoco:report` still produces `target/site/jacoco/index.html` because `jacoco-maven-plugin` stays.