### PR TITLE
Bump dependencies and tidy pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>3.2.1</version>
+        <version>3.4.0</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -142,7 +142,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
+        <version>2.21.0</version>
         <configuration>
           <rulesUri>file://${basedir}/version-rules.xml</rulesUri>
         </configuration>
@@ -150,7 +150,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M3</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -172,7 +172,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <auto-value.version>1.10.4</auto-value.version>
+    <auto-value.version>1.11.1</auto-value.version>
     <jacoco.version>0.8.14</jacoco.version>
   </properties>
 
@@ -180,12 +180,12 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>32.0.0-jre</version>
+      <version>33.6.0-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-testlib</artifactId>
-      <version>32.0.0-jre</version>
+      <version>33.6.0-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
@@ -206,25 +206,19 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>1.1.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.google.truth.extensions</groupId>
-      <artifactId>truth-java8-extension</artifactId>
-      <version>1.1.2</version>
+      <version>1.4.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>5.14.2</version>
+      <version>5.23.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-all</artifactId>
-      <version>1.3</version>
+      <artifactId>hamcrest</artifactId>
+      <version>3.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -248,18 +242,12 @@
   <profiles>
     <profile>
       <id>release-sign-artifacts</id>
-      <activation>
-        <property>
-          <name>performRelease</name>
-          <value>true</value>
-        </property>
-      </activation>
       <build>
         <plugins>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.6</version>
+            <version>3.2.8</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/src/test/java/com/google/acai/TestingServiceModuleTest.java
+++ b/src/test/java/com/google/acai/TestingServiceModuleTest.java
@@ -17,7 +17,6 @@
 package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 
 import com.google.inject.Guice;
 import com.google.inject.Injector;


### PR DESCRIPTION
## Summary

**Plugin versions**
- `maven-source-plugin` 3.2.1 → 3.4.0
- `maven-enforcer-plugin` 3.0.0-M3 → 3.6.2 (off the milestone line)
- `versions-maven-plugin` 2.8.1 → 2.21.0
- `maven-gpg-plugin` 1.6 (2014) → 3.2.8

**Dependencies**
- `guava` / `guava-testlib` 32.0.0-jre → 33.6.0-jre
- `mockito-core` 5.14.2 → 5.23.0
- `truth` 1.1.2 → 1.4.5
- `auto-value` 1.10.4 → 1.11.1
- `hamcrest-all` 1.3 (2012, retired artifact id) → `hamcrest` 3.0
- Drop `truth-java8-extension` — its content was folded into truth core in 1.4.x; `TestingServiceModuleTest`'s `Truth8` import was now ambiguous against the same signature in `Truth`

**Pom tidy**
- Drop the dead `<activation><property>performRelease=true` block from the `release-sign-artifacts` profile. `maven-release-plugin`'s `<releaseProfiles>` config now force-activates it by name during `release:perform`, so the property gate was unreachable.

## Test plan
- [x] `mvn -B clean test` — 43/43 tests pass on JDK 26
- [x] `mvn -B package` — main + sources + javadoc jars all build