### PR TITLE
Fix two error-prone warnings in tests

### DIFF
--- a/src/test/java/com/google/acai/DependenciesTest.java
+++ b/src/test/java/com/google/acai/DependenciesTest.java
@@ -38,8 +38,7 @@ public class DependenciesTest {
 
   @Test
   public void arbitraryOrdering() {
-    Set<TestingService> testingServices =
-        ImmutableSet.of(new ServiceA(), new ServiceB(), new ServiceA());
+    Set<TestingService> testingServices = ImmutableSet.of(new ServiceA(), new ServiceB());
 
     assertThat(Dependencies.inOrder(testingServices)).containsExactlyElementsIn(testingServices);
   }

--- a/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
+++ b/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
@@ -18,6 +18,7 @@ package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
+import static org.junit.Assert.assertThrows;
 
 import com.google.guiceberry.GuiceBerryEnvMain;
 import com.google.guiceberry.GuiceBerryModule;
@@ -128,24 +129,23 @@ public class GuiceberryCompatibilityModuleTest {
   }
 
   @Test
-  public void testWrapperExceptionPropagated() throws Throwable {
+  public void testWrapperExceptionPropagated() {
     FakeTestClass test = new FakeTestClass();
 
-    try {
-      new Acai(ThrowingWrapperModule.class)
-          .apply(
-              new Statement() {
-                @Override
-                public void evaluate() {
-                  assertWithMessage("Test should not run when TestWrapper throws").fail();
-                }
-              },
-              frameworkMethod,
-              test)
-          .evaluate();
-      assertWithMessage("Exception from TestWrapper should be propagated").fail();
-    } catch (TestException expected) {
-    }
+    assertThrows(
+        TestException.class,
+        () ->
+            new Acai(ThrowingWrapperModule.class)
+                .apply(
+                    new Statement() {
+                      @Override
+                      public void evaluate() {
+                        assertWithMessage("Test should not run when TestWrapper throws").fail();
+                      }
+                    },
+                    frameworkMethod,
+                    test)
+                .evaluate());
   }
 
   private static class FakeTestClass {


### PR DESCRIPTION
## Summary

- `GuiceberryCompatibilityModuleTest.testWrapperExceptionPropagated` was using the legacy try/catch-and-swallow idiom to assert that a `TestException` is thrown. Error-prone's `EmptyCatch` flagged the swallowed exception. Replaced with `assertThrows`, which states the intent explicitly.

- `DependenciesTest.arbitraryOrdering` passed `new ServiceA()` twice in an `ImmutableSet.of` varargs call. `DistinctVarargsChecker` flags this as the kind of thing that is almost always a copy-paste bug. The test only asserts that `Dependencies.inOrder` returns every input service for a set with no `@DependsOn` relationships — two distinct services express that equally well.

## Test plan
- [x] `mvn -B clean test` — 43/43 pass
- [x] No more `EmptyCatch` or `DistinctVarargsChecker` warnings in the build output