### PR TITLE
Document public API to silence javadoc warnings

### DIFF
--- a/src/main/java/com/google/acai/Acai.java
+++ b/src/main/java/com/google/acai/Acai.java
@@ -69,6 +69,12 @@ public class Acai implements MethodRule {
 
   private final Class<? extends Module> module;
 
+  /**
+   * Creates a rule that builds the test injector from {@code module}, which must have a no-arg
+   * constructor.
+   *
+   * @param module the Guice module class used to configure injection for tests using this rule
+   */
   public Acai(Class<? extends Module> module) {
     this.module = checkNotNull(module);
   }

--- a/src/main/java/com/google/acai/AcaiBoundFieldModule.java
+++ b/src/main/java/com/google/acai/AcaiBoundFieldModule.java
@@ -59,6 +59,8 @@ import java.util.function.Function;
  *   instance.get().foo(); // uses "default"
  * }
  * </code></pre>
+ *
+ * @param <T> the class whose {@code @Bind(lazy = true)} fields define the bindings
  */
 public final class AcaiBoundFieldModule<T> extends AbstractModule {
   private final Class<T> clazz;
@@ -75,9 +77,14 @@ public final class AcaiBoundFieldModule<T> extends AbstractModule {
   }
 
   /**
-   * Use like: {@code install(AcaiBoundFieldModule.of(Vars.class));} in your TestEnv.
+   * Returns a module that binds the {@code @Bind(lazy = true)} fields of {@code clazz} for use in a
+   * test. Use like: {@code install(AcaiBoundFieldModule.of(Vars.class));} in your TestEnv.
    *
    * <p>NOTE: The class passed must be {@code public static}.
+   *
+   * @param <T> the class whose annotated fields define the bindings
+   * @param clazz the class to instantiate via its no-arg constructor and inspect for bindings
+   * @return a module installing the discovered bindings
    */
   public static <T> AcaiBoundFieldModule<T> of(Class<T> clazz) {
     return new AcaiBoundFieldModule<>(clazz);

--- a/src/main/java/com/google/acai/DependsOn.java
+++ b/src/main/java/com/google/acai/DependsOn.java
@@ -37,5 +37,10 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Target(TYPE)
 public @interface DependsOn {
+  /**
+   * The testing services this service depends upon.
+   *
+   * @return the dependency classes
+   */
   Class<? extends TestingService>[] value();
 }

--- a/src/main/java/com/google/acai/TestingServiceModule.java
+++ b/src/main/java/com/google/acai/TestingServiceModule.java
@@ -40,7 +40,15 @@ import javax.inject.Singleton;
  */
 public abstract class TestingServiceModule extends AbstractModule {
 
-  /** Returns a new module which will configure bindings for all the specified {@code services}. */
+  /** Constructor for use by subclasses. */
+  protected TestingServiceModule() {}
+
+  /**
+   * Returns a new module which will configure bindings for all the specified {@code services}.
+   *
+   * @param services the testing service classes to bind
+   * @return a module installing those bindings
+   */
   public static TestingServiceModule forServices(
       Iterable<Class<? extends TestingService>> services) {
     return new TestingServiceModule() {
@@ -53,14 +61,24 @@ public abstract class TestingServiceModule extends AbstractModule {
     };
   }
 
-  /** Returns a new module which will configure bindings for all the specified {@code services}. */
+  /**
+   * Returns a new module which will configure bindings for all the specified {@code services}.
+   *
+   * @param services the testing service classes to bind
+   * @return a module installing those bindings
+   */
   @SafeVarargs
   @CheckReturnValue
   public static TestingServiceModule forServices(Class<? extends TestingService>... services) {
     return forServices(ImmutableList.copyOf(services));
   }
-  
-  /** Returns a new module which will configure bindings for all the specified {@code services}. */
+
+  /**
+   * Returns a new module which will bind the supplied {@code services} as instances.
+   *
+   * @param services the testing service instances to bind
+   * @return a module installing those bindings
+   */
   @CheckReturnValue
   public static TestingServiceModule forServices(TestingService... services) {
     return new TestingServiceModule() {
@@ -78,12 +96,22 @@ public abstract class TestingServiceModule extends AbstractModule {
     configureTestingServices();
   }
 
+  /**
+   * Binds {@code testingService} as a {@link TestingService} instance.
+   *
+   * @param testingService the instance to bind
+   */
   protected final void bindTestingService(TestingService testingService) {
     Multibinder.newSetBinder(this.binder(), TestingService.class, AcaiInternal.class)
         .addBinding()
         .toInstance(testingService);
   }
 
+  /**
+   * Binds {@code testingService} as a {@link TestingService} class.
+   *
+   * @param testingService the class to bind, instantiated by Guice on first use
+   */
   protected final void bindTestingService(Class<? extends TestingService> testingService) {
     Multibinder.newSetBinder(this.binder(), TestingService.class, AcaiInternal.class)
         .addBinding()


### PR DESCRIPTION
## Summary
Adds the missing javadoc tags on public/protected members that the modern javadoc tool flags. After this the build emits zero javadoc warnings.

- `Acai(Class)` constructor — added a brief comment + `@param`
- `AcaiBoundFieldModule<T>` type — added `@param <T>`
- `AcaiBoundFieldModule.of(Class)` — added `@param <T>`, `@param clazz`, `@return`
- `DependsOn.value()` — added a brief comment + `@return`
- `TestingServiceModule` — added an explicit `protected` no-arg constructor with a one-line doc (silences the implicit-default-constructor warning); added `@param services` / `@return` to the three `forServices` overloads; added `@param testingService` to the two `bindTestingService` overloads

No behaviour change.

## Test plan
- [x] `mvn -B clean package` — 43/43 tests pass, javadoc warnings gone