### PR TITLE
Treat compile warnings as errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,10 +59,11 @@
         <version>3.14.0</version>
         <configuration>
           <release>26</release>
+          <failOnWarning>true</failOnWarning>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne</arg>
+            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(test-)?sources/.*</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
@@ -95,6 +96,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>3.12.0</version>
+        <configuration>
+          <failOnWarnings>true</failOnWarnings>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>

--- a/src/test/java/com/google/acai/AcaiTest.java
+++ b/src/test/java/com/google/acai/AcaiTest.java
@@ -313,6 +313,7 @@ public class AcaiTest {
   }
 
   private static class TestWithUnsatisfiedBinding {
+    @SuppressWarnings("unused") // Fixture: injection should fail before this is read.
     @Inject @TestBindingAnnotation ExampleTest unsatisfiedBinding;
   }
 
@@ -342,6 +343,8 @@ public class AcaiTest {
     }
   }
 
+  // Fixture: existence of the non-zero-arg constructor is what the test verifies.
+  @SuppressWarnings("unused")
   private static class ModuleWithoutZeroArgumentConstructor extends AbstractModule {
     ModuleWithoutZeroArgumentConstructor(String argument) {
       // No-op.
@@ -381,6 +384,7 @@ public class AcaiTest {
   }
 
   private static class TearDownAccepterTest {
+    @SuppressWarnings("unused") // Forces @Provides to fire so the teardown is registered.
     @Inject @TestBindingAnnotation String injected;
   }
 

--- a/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
+++ b/src/test/java/com/google/acai/GuiceberryCompatibilityModuleTest.java
@@ -131,21 +131,19 @@ public class GuiceberryCompatibilityModuleTest {
   @Test
   public void testWrapperExceptionPropagated() {
     FakeTestClass test = new FakeTestClass();
+    Statement statement =
+        new Acai(ThrowingWrapperModule.class)
+            .apply(
+                new Statement() {
+                  @Override
+                  public void evaluate() {
+                    assertWithMessage("Test should not run when TestWrapper throws").fail();
+                  }
+                },
+                frameworkMethod,
+                test);
 
-    assertThrows(
-        TestException.class,
-        () ->
-            new Acai(ThrowingWrapperModule.class)
-                .apply(
-                    new Statement() {
-                      @Override
-                      public void evaluate() {
-                        assertWithMessage("Test should not run when TestWrapper throws").fail();
-                      }
-                    },
-                    frameworkMethod,
-                    test)
-                .evaluate());
+    assertThrows(TestException.class, statement::evaluate);
   }
 
   private static class FakeTestClass {

--- a/src/test/java/com/google/acai/TestScopeTest.java
+++ b/src/test/java/com/google/acai/TestScopeTest.java
@@ -253,6 +253,7 @@ public class TestScopeTest {
   private static class MyTestScopedClass {}
 
   private static class InvalidTestingService implements TestingService {
+    @SuppressWarnings("unused") // Fixture: @TestScoped injected into a TestingService is rejected.
     @Inject MyTestScopedClass testScoped;
   }
 

--- a/src/test/java/com/google/acai/TestingServiceManagerTest.java
+++ b/src/test/java/com/google/acai/TestingServiceManagerTest.java
@@ -150,6 +150,7 @@ public class TestingServiceManagerTest {
     }
 
     @BeforeTest
+    @SuppressWarnings("unused") // Parameter is the whole point: makes the method ineligible.
     private void incrementBeforeTestWithParameterCount(int someParameter) {
       beforeTestWithParameterCount++;
     }


### PR DESCRIPTION
## Summary
Now that the previous PRs cleared the long tail of error-prone and javadoc warnings, turn on the strict gates so any future regression breaks the build instead of being a silently ignored log line.

- `maven-compiler-plugin`: `<failOnWarning>true</failOnWarning>` (catches javac warnings + error-prone warnings)
- `maven-javadoc-plugin`: `<failOnWarnings>true</failOnWarnings>`

## Pre-requisite cleanups bundled in
To get to a clean build first:

- **5 test fixtures** got `@SuppressWarnings("unused")` with a one-line comment explaining the intent (injection that should fail before the field is read; non-zero-arg constructor that exists *only* so the test can verify the resulting error message; a method parameter that exists so the method gets filtered out as ineligible; etc.).
- **`testWrapperExceptionPropagated`** refactored so only the throwing call sits inside the `assertThrows` lambda — appeases `AssertThrowsMinimizer` (introduced by my fix in #51).
- **Error-prone** told to skip generated sources via `-XepExcludedPaths:.*/target/generated-(test-)?sources/.*`. AutoValue's generated `equals()` uses pre-pattern-matching `instanceof`, which we can't fix and shouldn't fail builds over.

## Test plan
- [x] `mvn -B clean package` — 43/43 tests pass, zero warnings, strict mode on