### PR TITLE
Replace AutoValue with records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,18 +63,13 @@
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
             <arg>--should-stop=ifError=FLOW</arg>
-            <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-(test-)?sources/.*</arg>
+            <arg>-Xplugin:ErrorProne</arg>
           </compilerArgs>
           <annotationProcessorPaths>
             <path>
               <groupId>com.google.errorprone</groupId>
               <artifactId>error_prone_core</artifactId>
               <version>2.49.0</version>
-            </path>
-            <path>
-              <groupId>com.google.auto.value</groupId>
-              <artifactId>auto-value</artifactId>
-              <version>${auto-value.version}</version>
             </path>
           </annotationProcessorPaths>
         </configuration>
@@ -120,11 +115,6 @@
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
         <version>${jacoco.version}</version>
-        <configuration>
-          <excludes>
-            <exclude>**/AutoValue_*</exclude>
-          </excludes>
-        </configuration>
         <executions>
           <execution>
             <goals>
@@ -176,7 +166,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <auto-value.version>1.11.1</auto-value.version>
     <jacoco.version>0.8.14</jacoco.version>
   </properties>
 
@@ -200,12 +189,6 @@
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>
       <version>6.0.0</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.auto.value</groupId>
-      <artifactId>auto-value-annotations</artifactId>
-      <version>${auto-value.version}</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.google.truth</groupId>

--- a/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
+++ b/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
@@ -16,7 +16,6 @@
 
 package com.google.acai;
 
-import com.google.auto.value.AutoValue;
 import com.google.inject.AbstractModule;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
@@ -39,14 +38,14 @@ import java.util.Optional;
 class GuiceberryCompatibilityModule extends AbstractModule {
   private static final String GUICEBRRY_TEST_SCOPED_ANNOTATION = "com.google.guiceberry.TestScoped";
   private static final MethodReference GUICEBERRY_ENV_MAIN_RUN =
-      MethodReference.create("com.google.guiceberry.GuiceBerryEnvMain", "run");
+      new MethodReference("com.google.guiceberry.GuiceBerryEnvMain", "run");
   private static final MethodReference TEST_WRAPPER_RUN_BEFORE_TEST =
-      MethodReference.create("com.google.guiceberry.TestWrapper", "toRunBeforeTest");
+      new MethodReference("com.google.guiceberry.TestWrapper", "toRunBeforeTest");
   private static final MethodReference TEST_SCOPE_LISTENER_ENTERING_SCOPE =
-      MethodReference.create(
+      new MethodReference(
           "com.google.inject.testing.guiceberry.TestScopeListener", "enteringScope");
   private static final MethodReference TEST_SCOPE_LISTENER_EXITING_SCOPE =
-      MethodReference.create(
+      new MethodReference(
           "com.google.inject.testing.guiceberry.TestScopeListener", "exitingScope");
 
   @Override
@@ -113,14 +112,5 @@ class GuiceberryCompatibilityModule extends AbstractModule {
     }
   }
 
-  @AutoValue
-  abstract static class MethodReference {
-    static MethodReference create(String className, String methodName) {
-      return new AutoValue_GuiceberryCompatibilityModule_MethodReference(className, methodName);
-    }
-
-    abstract String className();
-
-    abstract String methodName();
-  }
+  record MethodReference(String className, String methodName) {}
 }

--- a/src/test/java/com/google/acai/AcaiTest.java
+++ b/src/test/java/com/google/acai/AcaiTest.java
@@ -22,7 +22,6 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.google.auto.value.AutoValue;
 import com.google.common.testing.TearDownAccepter;
 import com.google.inject.AbstractModule;
 import com.google.inject.BindingAnnotation;
@@ -283,20 +282,13 @@ public class AcaiTest {
     }
   }
 
-  @AutoValue
-  abstract static class MethodCalls {
-    abstract int beforeSuite();
-
-    abstract int beforeTest();
-
-    abstract int afterTest();
-
+  record MethodCalls(int beforeSuite, int beforeTest, int afterTest) {
     static MethodCalls create() {
-      return new AutoValue_AcaiTest_MethodCalls(0, 0, 0);
+      return new MethodCalls(0, 0, 0);
     }
 
     static MethodCalls create(int beforeSuite, int beforeTest, int afterTest) {
-      return new AutoValue_AcaiTest_MethodCalls(beforeSuite, beforeTest, afterTest);
+      return new MethodCalls(beforeSuite, beforeTest, afterTest);
     }
 
     MethodCalls incrementBeforeSuite() {


### PR DESCRIPTION
## Summary
- Convert the two `@AutoValue` classes (`MethodReference`, `MethodCalls`) to records — both are simple value types with no builders or custom equality, so records map cleanly on Java 26.
- Drop the `auto-value` annotation processor, the `auto-value-annotations` dependency, the `auto-value.version` property, the jacoco `**/AutoValue_*` exclude, and the Error Prone `-XepExcludedPaths` arg that was only there to ignore AutoValue's generated sources.

## Test plan
- [x] `mvn package` (compile, tests, javadoc, sources, jacoco) — all 43 tests pass