### PR TITLE
Fix misleading error message in invokeIfBound

### DIFF
--- a/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
+++ b/src/main/java/com/google/acai/GuiceberryCompatibilityModule.java
@@ -100,7 +100,8 @@ class GuiceberryCompatibilityModule extends AbstractModule {
     } catch (InvocationTargetException e) {
       throw e.getCause();
     } catch (ReflectiveOperationException e) {
-      throw new RuntimeException("Failed to invoke run on GuiceBerryEnvMain", e);
+      throw new RuntimeException(
+          "Failed to invoke " + method.methodName() + " on " + method.className(), e);
     }
   }
 


### PR DESCRIPTION
## Summary
- `invokeIfBound` is generic over a `MethodReference`, but its `ReflectiveOperationException` catch block hardcoded `"Failed to invoke run on GuiceBerryEnvMain"`. It is also called for `TestWrapper.toRunBeforeTest`, `TestScopeListener.enteringScope`, and `TestScopeListener.exitingScope`, so the message was wrong in three of four call sites.
- Build the message from the `MethodReference` so it names the actual class and method that failed.

## Test plan
- [x] `mvn clean test` — all 43 tests pass