### PR TITLE
Migrate ExpectedException to assertThrows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,12 +203,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest</artifactId>
-      <version>3.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>

--- a/src/test/java/com/google/acai/AcaiTest.java
+++ b/src/test/java/com/google/acai/AcaiTest.java
@@ -19,6 +19,7 @@ package com.google.acai;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth.assertWithMessage;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -31,9 +32,7 @@ import java.lang.annotation.Retention;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -42,7 +41,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AcaiTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
   @Mock private Statement statement;
   @Mock private FrameworkMethod frameworkMethod;
 
@@ -95,12 +93,8 @@ public class AcaiTest {
   @Test
   public void failingTestInjectionDoesNotAffectSubsequentTests() throws Throwable {
     Acai acai = new Acai(TestModule.class);
-    try {
-      acai.apply(statement, frameworkMethod, new TestWithUnsatisfiedBinding()).evaluate();
-      assertWithMessage("Expected ConfigurationException to be thrown.").fail();
-    } catch (ConfigurationException e) {
-      // Expected: TestWithUnsatisfiedBinding requires binding not satisfied by TestModule.
-    }
+    Statement failing = acai.apply(statement, frameworkMethod, new TestWithUnsatisfiedBinding());
+    assertThrows(ConfigurationException.class, failing::evaluate);
 
     acai.apply(statement, frameworkMethod, new ExampleTest()).evaluate();
 
@@ -110,12 +104,8 @@ public class AcaiTest {
   @Test
   public void failingBeforeTestMethodDoesNotAffectSubsequentTests() throws Throwable {
     Acai acai = new Acai(FailingBeforeTestModule.class);
-    try {
-      acai.apply(statement, frameworkMethod, new ExampleTest()).evaluate();
-      assertWithMessage("Expected TestException to be thrown.").fail();
-    } catch (TestException e) {
-      // Expected: ServiceWithFailingBeforeTest throws TestException in @BeforeTest.
-    }
+    Statement failing = acai.apply(statement, frameworkMethod, new ExampleTest());
+    assertThrows(TestException.class, failing::evaluate);
 
     ServiceWithFailingBeforeTest.shouldFail = false;
     acai.apply(statement, frameworkMethod, new ExampleTest()).evaluate();
@@ -146,19 +136,20 @@ public class AcaiTest {
   }
 
   @Test
-  public void usefulErrorMessageWhenModuleMissingZeroArgConstructor() throws Throwable {
-    thrown.expectMessage("does not have zero argument constructor");
-    new Acai(ModuleWithoutZeroArgumentConstructor.class)
-        .apply(statement, frameworkMethod, new Object())
-        .evaluate();
+  public void usefulErrorMessageWhenModuleMissingZeroArgConstructor() {
+    Statement runner =
+        new Acai(ModuleWithoutZeroArgumentConstructor.class)
+            .apply(statement, frameworkMethod, new Object());
+    RuntimeException e = assertThrows(RuntimeException.class, runner::evaluate);
+    assertThat(e).hasMessageThat().contains("does not have zero argument constructor");
   }
 
   @Test
-  public void rethrowsExceptionThrownByModuleConstructor() throws Throwable {
-    thrown.expect(TestException.class);
-    new Acai(ModuleWithThrowingConstructor.class)
-        .apply(statement, frameworkMethod, new Object())
-        .evaluate();
+  public void rethrowsExceptionThrownByModuleConstructor() {
+    Statement runner =
+        new Acai(ModuleWithThrowingConstructor.class)
+            .apply(statement, frameworkMethod, new Object());
+    assertThrows(TestException.class, runner::evaluate);
   }
 
   @Test

--- a/src/test/java/com/google/acai/DependenciesTest.java
+++ b/src/test/java/com/google/acai/DependenciesTest.java
@@ -17,21 +17,18 @@
 package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.Set;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class DependenciesTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
   private static class ServiceA implements TestingService {}
 
   private static class ServiceB implements TestingService {}
@@ -98,8 +95,9 @@ public class DependenciesTest {
 
   @Test
   public void throwsExceptionIfCyclePresent() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Cycle");
-    Dependencies.inOrder(ImmutableSet.of(new A(), new B(), new C()));
+    ImmutableSet<TestingService> services = ImmutableSet.of(new A(), new B(), new C());
+    IllegalArgumentException e =
+        assertThrows(IllegalArgumentException.class, () -> Dependencies.inOrder(services));
+    assertThat(e).hasMessageThat().contains("Cycle");
   }
 }

--- a/src/test/java/com/google/acai/TestScopeTest.java
+++ b/src/test/java/com/google/acai/TestScopeTest.java
@@ -17,6 +17,7 @@
 package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
@@ -24,9 +25,7 @@ import com.google.inject.ProvisionException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -35,7 +34,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class TestScopeTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
   @Mock private Statement statement;
   @Mock private FrameworkMethod frameworkMethod;
 
@@ -61,12 +59,12 @@ public class TestScopeTest {
   }
 
   @Test
-  public void servicesInstantiatedOutsideTestScope() throws Throwable {
+  public void servicesInstantiatedOutsideTestScope() {
     FakeTestClass test = new FakeTestClass();
+    Statement runner = new Acai(InvalidTestModule.class).apply(statement, frameworkMethod, test);
 
-    thrown.expect(ProvisionException.class);
-    thrown.expectMessage("@TestScoped binding outside test");
-    new Acai(InvalidTestModule.class).apply(statement, frameworkMethod, test).evaluate();
+    ProvisionException e = assertThrows(ProvisionException.class, runner::evaluate);
+    assertThat(e).hasMessageThat().contains("@TestScoped binding outside test");
   }
 
   @Test

--- a/src/test/java/com/google/acai/TestingServiceManagerTest.java
+++ b/src/test/java/com/google/acai/TestingServiceManagerTest.java
@@ -17,17 +17,14 @@
 package com.google.acai;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.hamcrest.Matchers.isA;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class TestingServiceManagerTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void callBeforeSuiteMethod() {
@@ -93,28 +90,29 @@ public class TestingServiceManagerTest {
 
   @Test
   public void runtimeExceptionsPropagated() {
-    thrown.expect(TestRuntimeException.class);
-    new TestingServiceManager(
+    TestingServiceManager manager =
+        new TestingServiceManager(
             new TestingService() {
               @BeforeTest
               void beforeTest() {
                 throw new TestRuntimeException();
               }
-            })
-        .beforeTest();
+            });
+    assertThrows(TestRuntimeException.class, manager::beforeTest);
   }
 
   @Test
   public void checkedExceptionsPropagatedInsideRuntimeException() {
-    thrown.expectCause(isA(TestException.class));
-    new TestingServiceManager(
+    TestingServiceManager manager =
+        new TestingServiceManager(
             new TestingService() {
               @BeforeTest
               void beforeTest() throws TestException {
                 throw new TestException();
               }
-            })
-        .beforeTest();
+            });
+    RuntimeException e = assertThrows(RuntimeException.class, manager::beforeTest);
+    assertThat(e).hasCauseThat().isInstanceOf(TestException.class);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `ExpectedException` has been deprecated since JUnit 4.13 in favor of `assertThrows`, which scopes the expectation to a specific call rather than the whole test method.
- Convert all uses across `AcaiTest`, `DependenciesTest`, `TestScopeTest`, and `TestingServiceManagerTest`. Also convert two equivalent try/catch+`fail()` blocks in `AcaiTest`.
- Where relevant, hoist non-throwing setup (e.g. `Acai.apply(...)` returning a `Statement`) out of the `assertThrows` lambda to satisfy Error Prone's `AssertThrowsMinimizer`.

## Test plan
- [x] `mvn clean test` — all 43 tests pass