### PR TITLE
Use Stream.toList() instead of Collectors.toList()

### DIFF
--- a/src/main/java/com/google/acai/Acai.java
+++ b/src/main/java/com/google/acai/Acai.java
@@ -34,7 +34,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 import org.junit.rules.MethodRule;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -124,7 +123,7 @@ public class Acai implements MethodRule {
             Dependencies.inOrder(injector.getInstance(TESTING_SERVICES_KEY))
                 .stream()
                 .map(TestingServiceManager::new)
-                .collect(Collectors.toList()));
+                .toList());
     environments.put(module, testEnvironment);
     return testEnvironment;
   }


### PR DESCRIPTION
## Summary
- `Stream.toList()` (Java 16+) returns an immutable list, which is what the `TestEnvironment` constructor wants — it only iterates the result.
- Drops the now-unused `Collectors` import.

## Test plan
- [x] `mvn clean test` — all 43 tests pass